### PR TITLE
Add lib rt to fix an issue when compile for arch 88f6281

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ INSTALL = install
 RM      = rm -f
 MKDIR   = mkdir -p
 
-COMPILER_OPTIONS = -Wall -Os -s
+COMPILER_OPTIONS = -Wall -Os -s -lrt
 CFLAGS           := $(COMPILER_OPTIONS)
 CXXFLAGS         := $(COMPILER_OPTIONS)
 


### PR DESCRIPTION
I made a fix for the arch 88f6281 for Synology package.